### PR TITLE
Allow output context to be configured

### DIFF
--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/connector.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/connector.rb
@@ -58,14 +58,7 @@ class DataFoodConsortium::Connector::Connector
         # used to prefix properties
         # so the DFC's context can be used.
         # See https://github.com/datafoodconsortium/connector-ruby/issues/11.
-        inputContext = {
-            "dfc-b" => "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_BusinessOntology.owl#",
-            "dfc-p" => "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_ProductGlossary.owl#",
-            "dfc-t" => "https://github.com/datafoodconsortium/ontology/releases/latest/download/DFC_TechnicalOntology.owl#",
-            "dfc-m" => "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/measures.rdf#",
-		    "dfc-pt" => "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#",
-		    "dfc-f" => "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/facets.rdf#"
-        }
+        inputContext = DataFoodConsortium::Connector::Context.inputContext
 
         @context = "https://www.datafoodconsortium.org"
 

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/context.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/context.rb
@@ -62,6 +62,11 @@ module DataFoodConsortium
         "http://static.datafoodconsortium.org/ontologies/context.json",
         "http://www.datafoodconsortium.org/"
       )
+
+      # The hash serializer expects only string values in the context.
+      def self.inputContext
+        @inputContext = VERSION_1_8.select { |key, value| value.is_a? String }
+      end
     end
   end
 end

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/json_ld_serializer.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/json_ld_serializer.rb
@@ -33,15 +33,12 @@ class DataFoodConsortium::Connector::JsonLdSerializer
     def process(*subjects)
         return "" if subjects.empty?
 
-        inputs = []
-        
         # Insert an input context on each subject so the properties could be prefixed. This way,
         # the DFC's context can be used.
         # See https://github.com/datafoodconsortium/connector-ruby/issues/11.
-        subjects.each do |subject|
-            input = { "@context" => @outputContext }
-            input.merge!(subject.serialize(@hashSerializer))
-            inputs.push(input)
+        inputs = subjects.map do |subject|
+          # JSON::LD needs a context on every input using prefixes.
+          subject.serialize(@hashSerializer).merge("@context" => @outputContext)
         end
 
         jsonLd = JSON::LD::API.compact(inputs, @outputContext)

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/json_ld_serializer.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/json_ld_serializer.rb
@@ -30,12 +30,8 @@ class DataFoodConsortium::Connector::JsonLdSerializer
         @hashSerializer = VirtualAssembly::Semantizer::HashSerializer.new(inputContext)
     end
 
-    def process(subject, *subjects)
-        subjects.insert(0, subject)
-
-        if (subjects.empty?)
-            return ""
-        end
+    def process(*subjects)
+        return "" if subjects.empty?
 
         inputs = []
         

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/json_ld_serializer.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/json_ld_serializer.rb
@@ -43,7 +43,7 @@ class DataFoodConsortium::Connector::JsonLdSerializer
 
         jsonLd = JSON::LD::API.compact(inputs, @outputContext)
 
-        return JSON.generate(jsonLd)
+        JSON.generate(jsonLd)
     end
 
 end

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/json_ld_serializer.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/json_ld_serializer.rb
@@ -43,7 +43,7 @@ class DataFoodConsortium::Connector::JsonLdSerializer
         # the DFC's context can be used.
         # See https://github.com/datafoodconsortium/connector-ruby/issues/11.
         subjects.each do |subject|
-            input = { "@context" => "https://www.datafoodconsortium.org" }
+            input = { "@context" => @outputContext }
             input.merge!(subject.serialize(@hashSerializer))
             inputs.push(input)
         end


### PR DESCRIPTION
The API of the serializer advertised this option already but ignored it later on. Now we use it instead of repeating the context URL. This allows software to call the serialiser with their own context:

```rb
tomato = DataFoodConsortium::Connector::SuppliedProduct.new("https://myplatform.com/tomato")

inputContext = DataFoodConsortium::Connector::Context.inputContext
outputContext = "https://www.datafoodconsortium.org/wp-content/plugins/wordpress-context-jsonld/context.jsonld"
exporter = DataFoodConsortium::Connector::JsonLdSerializer.new(outputContext, inputContext)

exporter.process(tomato)
```

I also simplified some Ruby code along the way.