### PR TITLE
Improve SKOS Concept parsing to allow use of intermediate SKOS Concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 Ruby:
-- Fix random code changes of the generated code by sorting elements (e36a923).
-- Fix some tests so they can pass by changing the expected JSON (e36a923).
-- Enable loading of measures v1.0.2 (6ef17f7).
+- Fix random code changes of the generated code by sorting elements (e36a9236fa012f87946b34c36cd463709d1cd2c5).
+- Fix some tests so they can pass by changing the expected JSON (e36a9236fa012f87946b34c36cd463709d1cd2c5).
+- Enable loading of measures v1.0.2 (6ef17f7d4a19aebd9d89b544db115d36f7e6fe93).
+- Improve SKOS Concept parsing ([PR #10](https://github.com/datafoodconsortium/connector-codegen/pull/10)).
 
 ### Changed
 
 Ruby:
-- Preload context to avoid remote loading (4741acb).
+- Preload context to avoid remote loading (4741acb7b2a396dc56f66f0c3b5e2d64078c7130).
 
 ## [1.0.1] - 2023-11-06
 

--- a/src/org/datafoodconsortium/connector/codegen/queries.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/queries.mtl
@@ -154,6 +154,10 @@
 [query public isPrimitive(t: Type): Boolean = if (t.name = 'String' or t.name = 'Boolean' or t.name = 'Real' or t.name = 'Integer') then true else false endif /]
 [query public isPrimitive(anElement: TypedElement): Boolean = anElement.type.isPrimitive() /]
 
+[comment This specific to the ruby codegen /]
+[query public isSKOSConceptClass(c: Class): Boolean = (c.name = 'SKOSConcept') /]
+[query public isSKOSConceptClass(c: Classifier): Boolean = (c.name = 'SKOSConcept') /]
+
 [comment query public getAttributeForStereotypedOperation(c: Class, s: String, o: String): String 
 	= invoke('org.datafoodconsortium.connector.codegen.common.Common', 'getAttributeForStereotypedOperation(org.eclipse.uml2.uml.Class, java.lang.String, java.lang.String)', Sequence{c, s, o})
 /]

--- a/src/org/datafoodconsortium/connector/codegen/queries.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/queries.mtl
@@ -157,6 +157,7 @@
 [comment This specific to the ruby codegen /]
 [query public isSKOSConceptClass(c: Class): Boolean = (c.name = 'SKOSConcept') /]
 [query public isSKOSConceptClass(c: Classifier): Boolean = (c.name = 'SKOSConcept') /]
+[query public isPrefLabelsProperty(p: Property): Boolean = (p.name = 'prefLabels') /]
 
 [comment query public getAttributeForStereotypedOperation(c: Class, s: String, o: String): String 
 	= invoke('org.datafoodconsortium.connector.codegen.common.Common', 'getAttributeForStereotypedOperation(org.eclipse.uml2.uml.Class, java.lang.String, java.lang.String)', Sequence{c, s, o})

--- a/src/org/datafoodconsortium/connector/codegen/queries.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/queries.mtl
@@ -154,10 +154,8 @@
 [query public isPrimitive(t: Type): Boolean = if (t.name = 'String' or t.name = 'Boolean' or t.name = 'Real' or t.name = 'Integer') then true else false endif /]
 [query public isPrimitive(anElement: TypedElement): Boolean = anElement.type.isPrimitive() /]
 
-[comment This specific to the ruby codegen /]
-[query public isSKOSConceptClass(c: Class): Boolean = (c.name = 'SKOSConcept') /]
 [query public isSKOSConceptClass(c: Classifier): Boolean = (c.name = 'SKOSConcept') /]
-[query public isPrefLabelsProperty(p: Property): Boolean = (p.name = 'prefLabels') /]
+[query public isSKOSConceptPrefLabel(p: Property): Boolean = (p.name = 'prefLabels') /]
 
 [comment query public getAttributeForStereotypedOperation(c: Class, s: String, o: String): String 
 	= invoke('org.datafoodconsortium.connector.codegen.common.Common', 'getAttributeForStereotypedOperation(org.eclipse.uml2.uml.Class, java.lang.String, java.lang.String)', Sequence{c, s, o})

--- a/src/org/datafoodconsortium/connector/codegen/ruby/class.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/class.mtl
@@ -15,7 +15,8 @@
 class DataFoodConsortium::Connector::[aClass.name.toUpperFirst()/][generateGeneralization(aClass)/]
 
 	[if (aClass.isSemantic() and aClass.generalization->isEmpty())]include VirtualAssembly::Semantizer::SemanticObject[/if]
-
+	[if (isSKOSConceptClass(aClass))]include DataFoodConsortium::Connector::SKOSHelper[/if]
+	
 	[for (property: Property | aClass.ownedAttribute) separator('\n')]
 	# @return ['['/][property.type.name /][']'/]
 	attr_accessor :[property.name /]

--- a/src/org/datafoodconsortium/connector/codegen/ruby/class.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/class.mtl
@@ -15,7 +15,7 @@
 class DataFoodConsortium::Connector::[aClass.name.toUpperFirst()/][generateGeneralization(aClass)/]
 
 	[if (aClass.isSemantic() and aClass.generalization->isEmpty())]include VirtualAssembly::Semantizer::SemanticObject[/if]
-	[if (isSKOSConceptClass(aClass))]include DataFoodConsortium::Connector::SKOSHelper[/if]
+	[if (aClass.isSKOSConceptClass())]include DataFoodConsortium::Connector::SKOSHelper[/if]
 	
 	[for (property: Property | aClass.ownedAttribute) separator('\n')]
 	# @return ['['/][property.type.name /][']'/]

--- a/src/org/datafoodconsortium/connector/codegen/ruby/classifier.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/classifier.mtl
@@ -7,7 +7,7 @@
 [template public generateImports(classifier: Classifier)]
 [for (ei: ElementImport | classifier.elementImport->sortedBy(i: ElementImport | i.importedElement.name)) separator('\n')][if (ei.importedElement.oclIsTypeOf(Class))][generateImport(ei)/][/if][/for]
 [if (classifier.oclIsTypeOf(Class))]require "virtual_assembly/semantizer"[/if]
-[if (isSKOSConceptClass(classifier))]require 'datafoodconsortium/connector/skos_helper'[/if]
+[if (classifier.isSKOSConceptClass())]require 'datafoodconsortium/connector/skos_helper'[/if]
 [/template]
 
 [template public generateImport(ei: ElementImport)]require "datafoodconsortium/connector/[generateFileName(ei.importedElement.name) /]"[/template]

--- a/src/org/datafoodconsortium/connector/codegen/ruby/classifier.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/classifier.mtl
@@ -1,11 +1,13 @@
 [comment encoding = UTF-8 /]
 [module classifier('http://www.eclipse.org/uml2/5.0.0/UML')]
 
+[import org::datafoodconsortium::connector::codegen::queries /]
 [import org::datafoodconsortium::connector::codegen::ruby::common /]
 
 [template public generateImports(classifier: Classifier)]
 [for (ei: ElementImport | classifier.elementImport->sortedBy(i: ElementImport | i.importedElement.name)) separator('\n')][if (ei.importedElement.oclIsTypeOf(Class))][generateImport(ei)/][/if][/for]
 [if (classifier.oclIsTypeOf(Class))]require "virtual_assembly/semantizer"[/if]
+[if (isSKOSConceptClass(classifier))]require 'datafoodconsortium/connector/skos_helper'[/if]
 [/template]
 
 [template public generateImport(ei: ElementImport)]require "datafoodconsortium/connector/[generateFileName(ei.importedElement.name) /]"[/template]

--- a/src/org/datafoodconsortium/connector/codegen/ruby/operation.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/operation.mtl
@@ -20,7 +20,7 @@ end
 
 [template public generateConstructorBody(class: Class, operation: Operation)]
 [if not (class.generalization->isEmpty()) or class.isSemantic()]super([generateConstructorSuper(operation, class)/])[/if]
-[for (p: Property | class.ownedAttribute) separator('\n')][if (isPrefLabelsProperty(p))]# Sort locale alphabetically
+[for (p: Property | class.ownedAttribute) separator('\n')][if (p.isSKOSConceptPrefLabel())]# Sort locale alphabetically
 @[p.name /] = [p.name /].sort.to_h[else]@[p.name /] = [p.name /][/if][/for]
 
 [if (class.isSemantic())][generateSetSemanticType(class)/][/if]

--- a/src/org/datafoodconsortium/connector/codegen/ruby/operation.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/operation.mtl
@@ -20,7 +20,9 @@ end
 
 [template public generateConstructorBody(class: Class, operation: Operation)]
 [if not (class.generalization->isEmpty()) or class.isSemantic()]super([generateConstructorSuper(operation, class)/])[/if]
-[for (p: Property | class.ownedAttribute) separator('\n')]@[p.name /] = [p.name /][/for]
+[for (p: Property | class.ownedAttribute) separator('\n')][if (isPrefLabelsProperty(p))]# Sort locale alphabetically
+@[p.name /] = [p.name /].sort.to_h[else]@[p.name /] = [p.name /][/if][/for]
+
 [if (class.isSemantic())][generateSetSemanticType(class)/][/if]
 [for (property: Property | class.ownedAttribute->select(p: Property | p.isSemantic())) separator('\n')][generateSemanticProperty(property)/][/for]
 [/template]

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/CHANGELOG.md
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix some tests so they can pass by changing the expected JSON (e36a923).
 - Enable loading of measures v1.0.2 (6ef17f7).
 - Allow output context to be configured ([PR #8](https://github.com/datafoodconsortium/connector-codegen/pull/8)).
+- Improve SKOS Concept parsing )([PR #10](https://github.com/datafoodconsortium/connector-codegen/pull/10)).
 
 ### Changed
 

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/CHANGELOG.md
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix random code changes of the generated code by sorting elements (e36a923).
-- Fix some tests so they can pass by changing the expected JSON (e36a923).
-- Enable loading of measures v1.0.2 (6ef17f7).
+- Fix random code changes of the generated code by sorting elements (e36a9236fa012f87946b34c36cd463709d1cd2c5).
+- Fix some tests so they can pass by changing the expected JSON (e36a9236fa012f87946b34c36cd463709d1cd2c5).
+- Enable loading of measures v1.0.2 (6ef17f7d4a19aebd9d89b544db115d36f7e6fe93).
 - Allow output context to be configured ([PR #8](https://github.com/datafoodconsortium/connector-codegen/pull/8)).
 - Improve SKOS Concept parsing ([PR #10](https://github.com/datafoodconsortium/connector-codegen/pull/10)).
 

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/CHANGELOG.md
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix some tests so they can pass by changing the expected JSON (e36a923).
 - Enable loading of measures v1.0.2 (6ef17f7).
 - Allow output context to be configured ([PR #8](https://github.com/datafoodconsortium/connector-codegen/pull/8)).
-- Improve SKOS Concept parsing )([PR #10](https://github.com/datafoodconsortium/connector-codegen/pull/10)).
+- Improve SKOS Concept parsing ([PR #10](https://github.com/datafoodconsortium/connector-codegen/pull/10)).
 
 ### Changed
 

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_helper.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module DataFoodConsortium::Connector::SKOSHelper
+  def addAttribute(name, value)
+    self.instance_variable_set("@#{name}", value)
+    self.define_singleton_method(name) do
+      instance_variable_get("@#{name}")
+    end
+  end
+
+  def hasAttribute(name)
+    self.methods.include?(:"#{name}")
+  end
+end

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
@@ -120,7 +120,11 @@ class DataFoodConsortium::Connector::SKOSParser
     name = getValueWithoutPrefix(id)
 
     if !parent.hasAttribute(name)
-      parent.addAttribute(name, DataFoodConsortium::Connector::SKOSInstance.new)
+      if !@skosConcepts[id].nil?
+        parent.addAttribute(name, @skosConcepts[id])
+      else
+        parent.addAttribute(name, DataFoodConsortium::Connector::SKOSInstance.new)
+      end
     end
 
     # Leaf concepts, stop the process

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
@@ -88,7 +88,7 @@ class DataFoodConsortium::Connector::SKOSParser
 
   def createSKOSConcept(element)
     skosConcept = DataFoodConsortium::Connector::SKOSConcept.new(
-      element.id, broaders: element.broader, narrowers: element.narrower
+      element.id, broaders: element.broader, narrowers: element.narrower, prefLabels: element.label
     )
     skosConcept.semanticType = element.type
 

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
@@ -128,7 +128,7 @@ class DataFoodConsortium::Connector::SKOSParser
     name = getValueWithoutPrefix(id)
 
     if !parent.hasAttribute(name)
-      if @useSkosConcept && !@skosConcepts[id].nil?
+      if @useSkosConcept && @skosConcepts[id]
         parent.addAttribute(name, @skosConcepts[id])
       else
         parent.addAttribute(name, DataFoodConsortium::Connector::SKOSInstance.new)

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
@@ -29,6 +29,10 @@ require 'datafoodconsortium/connector/skos_parser_element'
 class DataFoodConsortium::Connector::SKOSInstance
   include DataFoodConsortium::Connector::SKOSHelper
 
+  # Return a list of singelton methods, ie the list of Concept available
+  def topConcepts
+    self.methods(false).sort
+  end
 end
 
 class DataFoodConsortium::Connector::SKOSParser

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
@@ -80,7 +80,9 @@ class DataFoodConsortium::Connector::SKOSParser
   protected
 
   def createSKOSConcept(element)
-    skosConcept = DataFoodConsortium::Connector::SKOSConcept.new(element.id)
+    skosConcept = DataFoodConsortium::Connector::SKOSConcept.new(
+      element.id, broaders: element.broader, narrowers: element.narrower
+    )
     skosConcept.semanticType = element.type
 
     skosConcept

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
@@ -22,20 +22,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+require 'datafoodconsortium/connector/skos_helper'
 require 'datafoodconsortium/connector/skos_concept'
 require 'datafoodconsortium/connector/skos_parser_element'
 
 class DataFoodConsortium::Connector::SKOSInstance
-  def addAttribute(name, value)
-    self.instance_variable_set("@#{name}", value)
-    self.define_singleton_method(name) do
-      instance_variable_get("@#{name}")
-    end
-  end
+  include DataFoodConsortium::Connector::SKOSHelper
 
-  def hasAttribute(name)
-    self.methods.include?(:"#{name}")
-  end
 end
 
 class DataFoodConsortium::Connector::SKOSParser

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser.rb
@@ -1,17 +1,19 @@
+# frozen_string_literal: true
+
 # MIT License
-# 
+#
 # Copyright (c) 2023 Maxime Lecoq <maxime@lecoqlibre.fr>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,120 +26,114 @@ require 'datafoodconsortium/connector/skos_concept'
 require 'datafoodconsortium/connector/skos_parser_element'
 
 class DataFoodConsortium::Connector::SKOSInstance
-
-    def addAttribute(name, value)
-        self.instance_variable_set("@#{name}", value)
-        self.define_singleton_method(name) do
-            return instance_variable_get("@#{name}")
-        end
+  def addAttribute(name, value)
+    self.instance_variable_set("@#{name}", value)
+    self.define_singleton_method(name) do
+      instance_variable_get("@#{name}")
     end
+  end
 
-    def hasAttribute(name)
-        return self.methods.include?(:"#{name}")
-    end
-    
+  def hasAttribute(name)
+    self.methods.include?(:"#{name}")
+  end
 end
 
 class DataFoodConsortium::Connector::SKOSParser
+  def initialize
+    @results = DataFoodConsortium::Connector::SKOSInstance.new
+    @skosConcepts = {}
+    @rootElements = []
+    @broaders = {}
+  end
 
-    def initialize()
-        @results = DataFoodConsortium::Connector::SKOSInstance.new
-        @skosConcepts = {}
-        @rootElements = []
-        @broaders = {}
-    end
+  def parse(data)
+    init
 
-    def parse(data)
-        init()
+    data.each do |element|
+      current = DataFoodConsortium::Connector::SKOSParserElement.new(element)
 
-        data.each do |element|
-            current = DataFoodConsortium::Connector::SKOSParserElement.new(element)
-            
-            if (current.isConcept?() || current.isCollection?())
-                if (!@skosConcepts.has_key?(current.id))
-                    concept = createSKOSConcept(current)
-                    @skosConcepts[current.id] = concept
-                end
-                
-                if (current.hasBroader())
-                    current.broader.each do |broaderId|
-                        if (!@broaders.has_key?(broaderId))
-                            @broaders[broaderId] = []
-                        end
+      if current.isConcept? || current.isCollection?
+        if !@skosConcepts.has_key?(current.id)
+          concept = createSKOSConcept(current)
+          @skosConcepts[current.id] = concept
+        end
 
-                        @broaders[broaderId].push(current.id)
-                    end
-
-                # No broader, save the concept to the root
-                else 
-                    @rootElements.push(current.id)
-                end
+        if current.hasBroader
+          current.broader.each do |broaderId|
+            if !@broaders.has_key?(broaderId)
+              @broaders[broaderId] = []
             end
-        end
-        
-        @rootElements.each do |rootElementId|
-            setResults(@results, rootElementId)
-        end
 
-        return @results
+            @broaders[broaderId].push(current.id)
+          end
+        # No broader, save the concept to the root
+        else
+          @rootElements.push(current.id)
+        end
+      end
     end
 
-    protected
-    
-    def createSKOSConcept(element)
-        skosConcept = DataFoodConsortium::Connector::SKOSConcept.new(element.id)
-        skosConcept.semanticType = element.type
-        return skosConcept
+    @rootElements.each do |rootElementId|
+      setResults(@results, rootElementId)
     end
 
-    def getValueWithoutPrefix(property)
-        name = 'undefined'
-        
-        if (!property.include?('http') && property.include?(':'))
-            name = property.split(':')[1]
-        elsif (property.include?('#'))
-            name = property.split('#')[1]
-        end
+    @results
+  end
 
-        name = name.gsub('-', '_');
+  protected
 
-        # workaround to fix concepts starting with a number
-        # see https://github.com/datafoodconsortium/connector-ruby/issues/3
-        # see https://github.com/datafoodconsortium/ontology/issues/66
-        if (name.match?("^[0-9]"))
-            name = "_" + name
-        end
+  def createSKOSConcept(element)
+    skosConcept = DataFoodConsortium::Connector::SKOSConcept.new(element.id)
+    skosConcept.semanticType = element.type
 
-        return name.upcase
+    skosConcept
+  end
+
+  def getValueWithoutPrefix(property)
+    name = 'undefined'
+
+    if !property.include?('http') && property.include?(':')
+      name = property.split(':')[1]
+    elsif property.include?('#')
+      name = property.split('#')[1]
     end
 
-    private 
-    
-    def init()
-        @results = DataFoodConsortium::Connector::SKOSInstance.new
-        @skosConcepts = {}
-        @rootElements = []
-        @broaders = {}
+    name = name.gsub('-', '_')
+
+    # workaround to fix concepts starting with a number
+    # see https://github.com/datafoodconsortium/connector-ruby/issues/3
+    # see https://github.com/datafoodconsortium/ontology/issues/66
+    name = "_" + name if name.match?("^[0-9]")
+
+    name.upcase
+  end
+
+  private
+
+  def init
+    @results = DataFoodConsortium::Connector::SKOSInstance.new
+    @skosConcepts = {}
+    @rootElements = []
+    @broaders = {}
+  end
+
+  def setResults(parent, id)
+    name = getValueWithoutPrefix(id)
+
+    if !parent.hasAttribute(name)
+      parent.addAttribute(name, DataFoodConsortium::Connector::SKOSInstance.new)
     end
 
-    def setResults(parent, id)
-        name = getValueWithoutPrefix(id)
-
-        if (!parent.hasAttribute(name))
-            parent.addAttribute(name, DataFoodConsortium::Connector::SKOSInstance.new)
-        end
-        
-        # Leaf concepts, stop the process
-        if (!@broaders.has_key?(id))
-            parent.instance_variable_set("@#{name}", @skosConcepts[id])
-            return
-        end
-
-        @broaders[id].each do |narrower|
-            childName = getValueWithoutPrefix(narrower)
-            parentSkosInstance = parent.instance_variable_get("@#{name}")
-            setResults(parentSkosInstance, narrower) # recursive call
-        end
+    # Leaf concepts, stop the process
+    if !@broaders.has_key?(id)
+      parent.instance_variable_set("@#{name}", @skosConcepts[id])
+      return
     end
 
+    @broaders[id].each do |narrower|
+      parentSkosInstance = parent.instance_variable_get("@#{name}")
+
+      setResults(parentSkosInstance, narrower) # recursive call
+    end
+  end
 end

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser_element.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser_element.rb
@@ -73,6 +73,10 @@ class DataFoodConsortium::Connector::SKOSParserElement
     @type == "http://www.w3.org/2004/02/skos/core#Collection" || @type == "skos:Collection"
   end
 
+  def isConceptScheme?
+    @type == "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+  end
+
   private
 
   def extractId(data)

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser_element.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser_element.rb
@@ -27,9 +27,11 @@ class DataFoodConsortium::Connector::SKOSParserElement
   attr_reader :id
   attr_reader :type
   attr_reader :broader
+  attr_reader :narrower
 
   def initialize(element)
     @broader = []
+    @narrower = []
 
     if element
       @id = element["@id"]
@@ -45,6 +47,12 @@ class DataFoodConsortium::Connector::SKOSParserElement
       if element["http://www.w3.org/2004/02/skos/core#broader"]
         element["http://www.w3.org/2004/02/skos/core#broader"].each do |broader|
           @broader.push(broader["@id"])
+        end
+      end
+
+      if element["http://www.w3.org/2004/02/skos/core#narrower"]
+        element["http://www.w3.org/2004/02/skos/core#narrower"].each do |narrower|
+          @narrower.push(narrower["@id"])
         end
       end
     else

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser_element.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser_element.rb
@@ -1,17 +1,19 @@
+# frozen_string_literal: true
+
 # MIT License
-# 
+#
 # Copyright (c) 2023 Maxime Lecoq <maxime@lecoqlibre.fr>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,57 +24,54 @@
 
 class DataFoodConsortium::Connector::SKOSParserElement
 
-    attr_reader :id
-    attr_reader :type
-    attr_reader :broader
+  attr_reader :id
+  attr_reader :type
+  attr_reader :broader
 
-    def initialize(element)
-        @broader = []
+  def initialize(element)
+    @broader = []
 
-        if (element)
-            @id = element["@id"]
+    if element
+      @id = element["@id"]
 
-            if (element["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"])
-                @type = extractId(element["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"])
-            elsif (element["@type"])
-                @type = extractId(element["@type"])
-            else 
-                @type = "undefined"
-            end
+      if element["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]
+        @type = extractId(element["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"])
+      elsif element["@type"]
+        @type = extractId(element["@type"])
+      else
+        @type = "undefined"
+      end
 
-            if (element["http://www.w3.org/2004/02/skos/core#broader"])
-                element["http://www.w3.org/2004/02/skos/core#broader"].each do |broader|
-                    @broader.push(broader["@id"])
-                end
-            end
-        else
-            @id = ""
-            @type = ""
+      if element["http://www.w3.org/2004/02/skos/core#broader"]
+        element["http://www.w3.org/2004/02/skos/core#broader"].each do |broader|
+          @broader.push(broader["@id"])
         end
+      end
+    else
+      @id = ""
+      @type = ""
     end
-    
-    def hasBroader()
-        return @broader.count > 0
-    end
-    
-    def isConcept?()
-        return @type == "http://www.w3.org/2004/02/skos/core#Concept" || @type == "skos:Concept"
-    end
-    
-    def isCollection?()
-        return @type == "http://www.w3.org/2004/02/skos/core#Collection" || @type == "skos:Collection"
-    end
-    
-    private
-    
-    def extractId(data)
-        id = data[0]
-        
-        if (id["@id"])
-            return id["@id"]
-        end
+  end
 
-        return id
-    end
+  def hasBroader()
+    @broader.count > 0
+  end
 
+  def isConcept?()
+    @type == "http://www.w3.org/2004/02/skos/core#Concept" || @type == "skos:Concept"
+  end
+
+  def isCollection?()
+    @type == "http://www.w3.org/2004/02/skos/core#Collection" || @type == "skos:Collection"
+  end
+
+  private
+
+  def extractId(data)
+    id = data[0]
+
+    return id["@id"] if id["@id"]
+
+    id
+  end
 end

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser_element.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/lib/datafoodconsortium/connector/skos_parser_element.rb
@@ -28,10 +28,12 @@ class DataFoodConsortium::Connector::SKOSParserElement
   attr_reader :type
   attr_reader :broader
   attr_reader :narrower
+  attr_reader :label
 
   def initialize(element)
     @broader = []
     @narrower = []
+    @label = {}
 
     if element
       @id = element["@id"]
@@ -53,6 +55,12 @@ class DataFoodConsortium::Connector::SKOSParserElement
       if element["http://www.w3.org/2004/02/skos/core#narrower"]
         element["http://www.w3.org/2004/02/skos/core#narrower"].each do |narrower|
           @narrower.push(narrower["@id"])
+        end
+      end
+
+      if element["http://www.w3.org/2004/02/skos/core#prefLabel"]
+        element["http://www.w3.org/2004/02/skos/core#prefLabel"].each do |label|
+          @label[label["@language"].to_sym] = label["@value"]
         end
       end
     else

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/spec/parse_with_skos_concept_spec.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/spec/parse_with_skos_concept_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+describe "parse with skos concept" do
+  let(:connector) { DataFoodConsortium::Connector::Connector.instance }
+
+  describe "productTypes" do
+    before { connector.loadProductTypes(parse_json_file("productTypes.json")) }
+
+    describe "topConcepts" do
+      it "returns a list of available topConcepts" do
+        product_types = connector.PRODUCT_TYPES.topConcepts
+
+        expected = [
+          :BAKERY, :DAIRY_PRODUCT, :DRINK, :FROZEN, :FRUIT, :INEDIBLE, :LOCAL_GROCERY_STORE,
+          :MEAT_PRODUCT, :VEGETABLE
+        ]
+        expect(product_types).to eq(expected)
+      end
+    end
+
+    it "parses the first level" do
+      drink_type = connector.PRODUCT_TYPES.DRINK
+
+      expect(drink_type.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
+      expect(drink_type.broaders).to eq([])
+      expect(drink_type.narrowers).to eq([:ALCOHOLIC_BEVERAGE, :SOFT_DRINK])
+    end
+
+    it "parses the second level" do
+      drink_type = connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
+
+      expect(drink_type.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
+      expect(drink_type.broaders).to eq([:DRINK])
+      expect(drink_type.narrowers).to eq([:FRUIT_JUICE, :LEMONADE, :SMOOTHIE])
+    end
+
+
+    it "parses leaf level" do
+      drink_type = connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.LEMONADE
+
+      expect(drink_type.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
+      expect(drink_type.broaders).to eq([:SOFT_DRINK])
+      expect(drink_type.narrowers).to eq([])
+    end
+  end
+
+
+  describe "facets" do
+    before { connector.loadFacets(parse_json_file("facets.json")) }
+
+    describe "topConcepts" do
+      it "returns a list of available topConcepts" do
+        facets = connector.FACETS.topConcepts
+
+        expected = [:CERTIFICATION, :CLAIM, :NATUREORIGIN, :PARTORIGIN, :TERRITORIALORIGIN]
+        expect(facets).to eq(expected)
+      end
+    end
+
+    # We tested with Product Types further levels up to a leaf. So it's fair to expect
+    # if the first level is good, the others are as well due to the recursive nature of the parser
+    it "parses the first level" do
+      facet = connector.FACETS.CERTIFICATION
+
+      expect(facet.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
+      expect(facet.broaders).to eq([])
+      expect(facet.narrowers).to eq(
+        [:ORGANICLABEL, :LOCALLABEL, :BIODYNAMICLABEL, :ETHICALLABEL, :MARKETINGLABEL]
+      )
+    end
+  end
+end

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/spec/parse_with_skos_concept_spec.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/spec/parse_with_skos_concept_spec.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-require 'datafoodconsortium/connector/data_reading_helper'
-
 describe "parse with skos concept" do
-  let(:connector) { DataFoodConsortium::Connector::Connector.instance }
-
   describe "productTypes" do
-    before { connector.loadProductTypes(parse_json_file("productTypes.json")) }
-
     describe "topConcepts" do
       it "returns a list of available topConcepts" do
         product_types = connector.PRODUCT_TYPES.topConcepts
@@ -30,33 +24,31 @@ describe "parse with skos concept" do
     it "parses the first level" do
       drink_type = connector.PRODUCT_TYPES.DRINK
 
-      expect(drink_type.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
+      expect(drink_type).to be_a DataFoodConsortium::Connector::SKOSConcept
       expect(drink_type.broaders).to eq([])
-      assert_array_includes(drink_type.narrowers, ["alcoholic-beverage", "soft-drink"])
+      expect(drink_type.narrowers).to include(/alcoholic-beverage/, /soft-drink/)
     end
 
     it "parses the second level" do
       drink_type = connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
 
-      expect(drink_type.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
-      assert_array_includes(drink_type.broaders, ["drink"])
-      assert_array_includes(drink_type.narrowers,["fruit-juice", "lemonade", "smoothie"])
+      expect(drink_type).to be_a DataFoodConsortium::Connector::SKOSConcept
+      expect(drink_type.broaders).to include(/drink/)
+      expect(drink_type.narrowers).to include(/fruit-juice/, /lemonade/, /smoothie/)
     end
 
 
     it "parses leaf level" do
       drink_type = connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.LEMONADE
 
-      expect(drink_type.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
-      assert_array_includes(drink_type.broaders, ["soft-drink"])
+      expect(drink_type).to be_a DataFoodConsortium::Connector::SKOSConcept
+      expect(drink_type.broaders).to include(/soft-drink/)
       expect(drink_type.narrowers).to eq([])
     end
   end
 
 
   describe "facets" do
-    before { connector.loadFacets(parse_json_file("facets.json")) }
-
     describe "topConcepts" do
       it "returns a list of available topConcepts" do
         facets = connector.FACETS.topConcepts
@@ -71,18 +63,11 @@ describe "parse with skos concept" do
     it "parses the first level" do
       facet = connector.FACETS.CERTIFICATION
 
-      expect(facet.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
+      expect(facet).to be_a DataFoodConsortium::Connector::SKOSConcept
       expect(facet.broaders).to eq([])
-      assert_array_includes(
-        facet.narrowers,
-        ["OrganicLabel", "LocalLabel", "BiodynamicLabel", "EthicalLabel", "MarketingLabel"]
+      expect(facet.narrowers).to include(
+        /OrganicLabel/, /LocalLabel/, /BiodynamicLabel/, /EthicalLabel/, /MarketingLabel/
       )
-    end
-  end
-
-  def assert_array_includes(array, value)
-    array.each_with_index do |a, i|
-      expect(a).to include(value[i])
     end
   end
 end

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/spec/parse_with_skos_concept_spec.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/spec/parse_with_skos_concept_spec.rb
@@ -20,6 +20,13 @@ describe "parse with skos concept" do
       end
     end
 
+    describe "prefLabels" do
+      it "populates SKOS Concept prefLabels" do
+        drink_type = connector.PRODUCT_TYPES.DRINK
+        expect(drink_type.prefLabels).to eq({en: "drink", fr: "boisson" })
+      end
+    end
+
     it "parses the first level" do
       drink_type = connector.PRODUCT_TYPES.DRINK
 

--- a/src/org/datafoodconsortium/connector/codegen/ruby/static/spec/parse_with_skos_concept_spec.rb
+++ b/src/org/datafoodconsortium/connector/codegen/ruby/static/spec/parse_with_skos_concept_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'datafoodconsortium/connector/data_reading_helper'
+
 describe "parse with skos concept" do
   let(:connector) { DataFoodConsortium::Connector::Connector.instance }
 
@@ -23,15 +25,15 @@ describe "parse with skos concept" do
 
       expect(drink_type.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
       expect(drink_type.broaders).to eq([])
-      expect(drink_type.narrowers).to eq([:ALCOHOLIC_BEVERAGE, :SOFT_DRINK])
+      assert_array_includes(drink_type.narrowers, ["alcoholic-beverage", "soft-drink"])
     end
 
     it "parses the second level" do
       drink_type = connector.PRODUCT_TYPES.DRINK.SOFT_DRINK
 
       expect(drink_type.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
-      expect(drink_type.broaders).to eq([:DRINK])
-      expect(drink_type.narrowers).to eq([:FRUIT_JUICE, :LEMONADE, :SMOOTHIE])
+      assert_array_includes(drink_type.broaders, ["drink"])
+      assert_array_includes(drink_type.narrowers,["fruit-juice", "lemonade", "smoothie"])
     end
 
 
@@ -39,7 +41,7 @@ describe "parse with skos concept" do
       drink_type = connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.LEMONADE
 
       expect(drink_type.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
-      expect(drink_type.broaders).to eq([:SOFT_DRINK])
+      assert_array_includes(drink_type.broaders, ["soft-drink"])
       expect(drink_type.narrowers).to eq([])
     end
   end
@@ -64,9 +66,16 @@ describe "parse with skos concept" do
 
       expect(facet.is_a?(DataFoodConsortium::Connector::SKOSConcept)).to be(true)
       expect(facet.broaders).to eq([])
-      expect(facet.narrowers).to eq(
-        [:ORGANICLABEL, :LOCALLABEL, :BIODYNAMICLABEL, :ETHICALLABEL, :MARKETINGLABEL]
+      assert_array_includes(
+        facet.narrowers,
+        ["OrganicLabel", "LocalLabel", "BiodynamicLabel", "EthicalLabel", "MarketingLabel"]
       )
+    end
+  end
+
+  def assert_array_includes(array, value)
+    array.each_with_index do |a, i|
+      expect(a).to include(value[i])
     end
   end
 end


### PR DESCRIPTION
This PR fixes the following issues : 
* https://github.com/datafoodconsortium/connector-ruby/issues/13
* https://github.com/datafoodconsortium/connector-ruby/issues/9

Additional background : https://github.com/datafoodconsortium/connector-ruby/issues/13#issuecomment-1786333685

It allows the ruby connector to use intermediate SKOS concept for Product Types and Facets ie: 
* `connector.FACETS.TERRITORIALORIGIN.EUROPE.FRANCE`
* `connector.PRODUCT_TYPES.DRINK.SOFT_DRINK`

It didn't make sense to use intermediate for Measures so I kept the original behaviour (it can be easily fixed if needed)

I am not familiar with the design, but I don't think it makes sense for `DataFoodConsortium::Connector::SKOSConcept` to be a subclass of `DataFoodConsortium::Connector::SKOSInstance`, so I used a helper module to share method needed by both class.
This also populates `narrowers` and `broaders` for `SKOSConcept` so it's easier to navigate the tree. Ideally I would have like them to return a list of methods so could do something like below without additional steps :

```ruby
types = connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.narrowers 
# [:FRUIT_JUICE, :LEMONADE, :SMOOTHIE]

# Access connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.FRUIT_JUICE
connector.PRODUCT_TYPES.DRINK.SOFT_DRINK.public_send(types.first)
```

I didn't want to alter the existing behaviour of `DataFoodConsortium::Connector::SKOSConcept#narrowers`, that said the original values would still be available via `skos:narrower` semantic property. Any thought ? 

This also populates `prefLabels` for `DataFoodConsortium::Connector::SKOSConcept`, I used an hash with locale has keys for ease of use ie : 
```ruby
{
  en: "drink",
  fr: "boisson" 
}
```
