### PR TITLE
TypeScript alpha-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `getOperationsToImplementOrDeclareFromInterfacesWithoutParents`.
   - `getOperationsToImplementOrDeclare`.
 
+### Changed
+TypeScript:
+- Ensure the entry point, `src/index.ts`, is always regenerated on fresh builds.
+
+### Fixed
+TypeScript:
+- Fix setters for array properties so that all items are replaced.
+
 ## [1.1.0] - 2024-10-22
 
 ### Added

--- a/src/org/datafoodconsortium/connector/codegen/typescript/generate.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/generate.mtl
@@ -13,5 +13,26 @@
 
 [for (aClass: Class | model.getConcreateClasses())][generateClassTest(model, aClass)/][/for]
 
+[generateIndex(model) /]
+
 [comment TODO: write factory generator][model.generateFactory()/][/comment]
+
+[/template]
+
+[template public generateIndex(model: Model)]
+[file (getProperty('typescript_outputFolder_src') + 'index.ts', false, 'UTF-8')]
+export { default as Connector } from './Connector.js';
+export { default as ConnectorStoreMap } from './ConnectorStoreMap.js';
+export { default as ConnectorFactory } from './ConnectorFactory.js';
+export { default as ConnectorExporterJsonldStream } from './ConnectorExporterJsonldStream.js';
+export { default as ConnectorImporterJsonldStream } from './ConnectorImporterJsonldStream.js';
+[for (importedPackage: PackageImport | model.packageImport->select(pi: PackageImport | pi.importedPackage.name <> 'org.datafoodconsortium.semantizer'))][generateExport(importedPackage.importedPackage.ownedMember)/][/for]
+[generateExport(model.ownedMember)/]
+[/file]
+[/template]
+
+[template public generateExport(members: Set(NamedElement))]
+[for (member: NamedElement | members->select(ne: NamedElement | ne.oclIsTypeOf(Class) or ne.oclIsTypeOf(Interface)))]
+export { default as [member.name/] } from './[member.name/].js';
+[/for]
 [/template]

--- a/src/org/datafoodconsortium/connector/codegen/typescript/operation.mtl
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/operation.mtl
@@ -141,8 +141,18 @@ return [if (returned.type.name = 'Real' or returned.type.name = 'Integer')]Numbe
 [/template]
 
 [template public generateSetterBody(aClass: Class, operation: Operation)]
-[let parameter: Parameter = operation.getInputParameter()][let property: Property = operation.getProperty(aClass)][let map: String = property.getMapping()]
-[if (parameter.type.isPrimitive())]this.setSemanticPropertyLiteral("[map/]", [parameter.name/]);[else]this.setSemanticProperty[if (parameter.type.isBlankNode())]Anonymous[else]Reference[/if]("[map/]", [parameter.name/]);
+[let parameter: Parameter = operation.getInputParameter()]
+[let property: Property = operation.getProperty(aClass)]
+[let map: String = property.getMapping()][if (parameter.type.isPrimitive())]
+this.setSemanticPropertyLiteral("[map/]", [parameter.name/]);[elseif (parameter.upper = -1)]
+this.getSemanticPropertyAll("[map/]").forEach((prop) => {
+	this.connector.removeFromStore(prop);
+});
+[let obj: String = aClass.name.toLowerFirst()][parameter.name/].forEach(([obj/]) => {
+	this.addSemanticPropertyReference("[map/]", [obj/], true);
+	this.connector.store([obj/]);
+});[/let][else]
+this.setSemanticProperty[if (parameter.type.isBlankNode())]Anonymous[else]Reference[/if]("[map/]", [parameter.name/]);
 [if (not parameter.type.isBlankNode())]['\n'/]this.connector.store([parameter.name/]);[/if][/if][/let][/let][/let]
 [/template]
 

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/.gitignore
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/CHANGELOG.md
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/CHANGELOG.md
@@ -9,13 +9,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- None
 
 ### Changed
 - Ensure the entry point, `src/index.ts`, is always regenerated on fresh builds.
+
+## [1.0.0-alpha.10] - 2025-03-01
+
+### Changed
+- Ensure the entry point, `src/index.ts`, is always regenerated on fresh builds.
+- Fix setters for array properties so that all items are replaced.
 - Regenerate source and distribution code from the next branch of UML data model
   [621e823](https://github.com/datafoodconsortium/data-model-uml/commit/621e823c21c79a58b117bae97132da9140e47be6).
-- Upgrade `jsonld-streaming-parser` to v4
-- Upgrade `jsonld-context-parser` to v3
 
 ### Added
 - `DefinedProduct`:
@@ -175,7 +180,8 @@ See the SUPPORTED.md file [comparison from main to next](https://github.com/data
 
 - Initial release.
 
-[unreleased]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.9...HEAD
+[unreleased]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.10...HEAD
+[1.0.0-alpha.10]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.9...v1.0.0-alpha.10
 [1.0.0-alpha.9]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.8...v1.0.0-alpha.9
 [1.0.0-alpha.8]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.7...v1.0.0-alpha.8
 [1.0.0-alpha.7]: https://github.com/datafoodconsortium/connector-typescript/compare/v1.0.0-alpha.6...v1.0.0-alpha.7

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/CHANGELOG.md
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/CHANGELOG.md
@@ -10,7 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- None
+### Changed
+- Ensure the entry point, `src/index.ts`, is always regenerated on fresh builds.
+- Regenerate source and distribution code from the next branch of UML data model
+  [621e823](https://github.com/datafoodconsortium/data-model-uml/commit/621e823c21c79a58b117bae97132da9140e47be6).
+- Upgrade `jsonld-streaming-parser` to v4
+- Upgrade `jsonld-context-parser` to v3
+
+### Added
+- `DefinedProduct`:
+  - hasVariant
+  - isVariantOf
+
+### Fixed
+- Fix setters for array properties so that all items are replaced.
 
 ## [1.0.0-alpha.9] - 2024-03-21
 

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/CHANGELOG.md
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/CHANGELOG.md
@@ -9,18 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - None
 
-### Changed
-- Ensure the entry point, `src/index.ts`, is always regenerated on fresh builds.
-
-## [1.0.0-alpha.10] - 2025-03-01
+## [1.0.0-alpha.10] - 2025-04-28
 
 ### Changed
 - Ensure the entry point, `src/index.ts`, is always regenerated on fresh builds.
-- Fix setters for array properties so that all items are replaced.
-- Regenerate source and distribution code from the next branch of UML data model
-  [621e823](https://github.com/datafoodconsortium/data-model-uml/commit/621e823c21c79a58b117bae97132da9140e47be6).
+- Generated from updated [UML Model](https://github.com/datafoodconsortium/data-model-uml/):
+  - Release: [3.0.0](https://github.com/datafoodconsortium/data-model-uml/releases/tag/v3.0.0)
+  - Commit: [@732bc8e](https://github.com/datafoodconsortium/data-model-uml/commit/732bc8e5cbbf55818ce36330a6c58031d740fefa)
 
 ### Added
 - `DefinedProduct`:

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/package-lock.json
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datafoodconsortium/connector",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.0-alpha.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@datafoodconsortium/connector",
-      "version": "1.0.0-alpha.9",
+      "version": "1.0.0-alpha.10",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/serializer-jsonld-ext": "^4.0.0",
@@ -362,6 +362,11 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "node_modules/@types/rdf-ext": {
       "version": "2.5.0",
@@ -1175,9 +1180,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/package-lock.json
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/package-lock.json
@@ -12,12 +12,13 @@
         "@rdfjs/serializer-jsonld-ext": "^4.0.0",
         "@virtual-assembly/semantizer": "github:assemblee-virtuelle/semantizer-typescript#alpha.3",
         "jsonld": "^8.1.0",
-        "jsonld-streaming-parser": "^3.2.0",
+        "jsonld-streaming-parser": "^4.0.1",
         "rdf-ext": "^2.5.1",
         "readable-stream": "^4.3.0"
       },
       "devDependencies": {
         "@types/jsonld": "^1.5.7",
+        "@types/node": "^22.7.6",
         "@types/rdf-ext": "^2.5.0",
         "@types/rdfjs__serializer-jsonld-ext": "^2.0.5",
         "typescript": "^4.5"
@@ -138,6 +139,51 @@
         "jsonld-streaming-parser": "^3.3.0",
         "readable-stream": "^4.5.2"
       }
+    },
+    "node_modules/@rdfjs/parser-jsonld/node_modules/@types/node": {
+      "version": "18.19.83",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.83.tgz",
+      "integrity": "sha512-D69JeR5SfFS5H6FLbUaS0vE4r1dGhmMBbG4Ed6BNS4wkDK8GZjsdCShT5LCN59vOHEUHnFCY9J4aclXlIphMkA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@rdfjs/parser-jsonld/node_modules/jsonld-context-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/@rdfjs/parser-jsonld/node_modules/jsonld-streaming-parser": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.4.0.tgz",
+      "integrity": "sha512-897CloyQgQidfkB04dLM5XaAXVX/cN9A2hvgHJo4y4jRhIpvg3KLMBBfcrswepV2N3T8c/Rp2JeFdWfVsbVZ7g==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.4.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/@rdfjs/parser-jsonld/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/@rdfjs/parser-n3": {
       "version": "2.0.2",
@@ -296,9 +342,9 @@
       }
     },
     "node_modules/@types/http-link-header": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.5.tgz",
-      "integrity": "sha512-AxhIKR8UbyoqCTNp9rRepkktHuUOw3DjfOfDCaO9kwI8AYzjhxyrvZq4+mRw/2daD3hYDknrtSeV6SsPwmc71w==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.7.tgz",
+      "integrity": "sha512-snm5oLckop0K3cTDAiBnZDy6ncx9DJ3mCRDvs42C884MbVYPP74Tiq2hFsSDRTyjK6RyDYDIulPiW23ge+g5Lw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -310,11 +356,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
-      "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
+      "version": "22.13.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
+      "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/rdf-ext": {
@@ -591,11 +637,11 @@
       "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
       "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -680,9 +726,9 @@
       }
     },
     "node_modules/http-link-header": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.2.tgz",
-      "integrity": "sha512-6qz1XhMq/ryde52SZGzVhzi3jcG2KqO16KITkupyQxvW6u7iylm0Fq7r3OpCYsc0S0ELlCiFpuxDcccUwjbEqA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -732,13 +778,12 @@
       }
     },
     "node_modules/jsonld-context-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
-      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-3.0.0.tgz",
+      "integrity": "sha512-Kg6TVtBUdIm057ht/8WNhM9BROt+BeYaDGXbzrKaa3xA99csee+CsD8IMCTizRgzoO8PIzvzcxxCoRvpq1xNQw==",
       "dependencies": {
         "@types/http-link-header": "^1.0.1",
         "@types/node": "^18.0.0",
-        "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.5"
       },
@@ -747,28 +792,46 @@
       }
     },
     "node_modules/jsonld-context-parser/node_modules/@types/node": {
-      "version": "18.19.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.24.tgz",
-      "integrity": "sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==",
+      "version": "18.19.83",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.83.tgz",
+      "integrity": "sha512-D69JeR5SfFS5H6FLbUaS0vE4r1dGhmMBbG4Ed6BNS4wkDK8GZjsdCShT5LCN59vOHEUHnFCY9J4aclXlIphMkA==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/jsonld-context-parser/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
     "node_modules/jsonld-streaming-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.3.0.tgz",
-      "integrity": "sha512-6aWiAsWGZioTB/vNQ3KenREz9ddEOliZoEETi+jLrlL7+vkgMeHjnxyFlGe4UOCU7SVUNPhz/lgLGZjnxgVYtA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-4.0.1.tgz",
+      "integrity": "sha512-6M4y9YGgADk3nXJebbRrxEdMVBJ9bnz+peAvjTXUievopqaE8sg/qml/I6Sp1ln7rpOKffsNZWSre6B7N76szw==",
       "dependencies": {
         "@bergos/jsonparse": "^1.4.0",
         "@rdfjs/types": "*",
         "@types/http-link-header": "^1.0.1",
-        "@types/readable-stream": "^2.3.13",
+        "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
         "canonicalize": "^1.0.1",
         "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.4.0",
+        "jsonld-context-parser": "^3.0.0",
         "rdf-data-factory": "^1.1.0",
         "readable-stream": "^4.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/@types/readable-stream": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.18.tgz",
+      "integrity": "sha512-21jK/1j+Wg+7jVw1xnSwy/2Q1VgVjWuFssbYGTREPUBeZ+rqVFl2udq0IkxzPC0ZhOzVceUbyIACFZKLqKEBlA==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
       }
     },
     "node_modules/ky": {
@@ -1123,9 +1186,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "node_modules/validate-iri": {
       "version": "1.0.1",

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/package.json
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/package.json
@@ -18,7 +18,7 @@
     "@rdfjs/serializer-jsonld-ext": "^4.0.0",
     "@virtual-assembly/semantizer": "github:assemblee-virtuelle/semantizer-typescript#alpha.3",
     "jsonld": "^8.1.0",
-    "jsonld-streaming-parser": "^3.2.0",
+    "jsonld-streaming-parser": "^4.0.1",
     "rdf-ext": "^2.5.1",
     "readable-stream": "^4.3.0"
   },

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/package.json
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/package.json
@@ -4,7 +4,7 @@
   "author": "Maxime Lecoq",
   "license": "MIT",
   "type": "module",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.0-alpha.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/datafoodconsortium/connector-typescript.git",

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/src/Connector.ts
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/src/Connector.ts
@@ -352,4 +352,8 @@ export default class Connector implements IConnector {
     public store(semanticObject: Semanticable): void {
         this.storeObject.set(semanticObject);
     }
+
+    public removeFromStore(semanticObjectId: string): void {
+        this.storeObject.remove(semanticObjectId);
+    }
 }

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/src/ConnectorStoreMap.ts
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/src/ConnectorStoreMap.ts
@@ -17,6 +17,10 @@ export default class ConnectorStoreMap implements IConnectorStore {
         return this.storeObject.has(semanticObjectId);
     }
 
+    public remove(semanticObjectId: string): void {
+        this.storeObject.delete(semanticObjectId);
+    }
+
     public set(semanticObject: Semanticable): void {
         const semanticId: string = semanticObject.getSemanticId();
         if (semanticId !== "")

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/src/IConnector.ts
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/src/IConnector.ts
@@ -30,6 +30,7 @@ import IPlannedConsumptionFlow from "./IPlannedConsumptionFlow.js";
 import IPlannedProductionFlow from "./IPlannedProductionFlow.js";
 import IPlannedTransformation from "./IPlannedTransformation.js";
 import IDefinedProduct from "./IDefinedProduct.js";
+import IConnectorStore from "./IConnectorStore.js";
 
 export default interface IConnector {
     
@@ -66,5 +67,6 @@ export default interface IConnector {
     importOneTyped<Type>(data: string, options?: IConnectorImportOptions): Promise<Type | undefined>;
     
     store(semanticObject: Semanticable): void;
+    removeFromStore(semanticObjectId: string): void;
 
 }

--- a/src/org/datafoodconsortium/connector/codegen/typescript/static/src/IConnectorStore.ts
+++ b/src/org/datafoodconsortium/connector/codegen/typescript/static/src/IConnectorStore.ts
@@ -4,6 +4,7 @@ import { Semanticable } from "@virtual-assembly/semantizer"
 export default interface IConnectorStore {
     get(semanticObjectId: string): Promise<Semanticable | undefined>;
     has(semanticObjectId: string): boolean;
+    remove(semanticObjectId: string): void;
     set(semanticObject: Semanticable): void;
     setAll(semanticObjects: Array<Semanticable>): void;
 }


### PR DESCRIPTION
Sorry this is a little stale. This incorporates some fixes I introduced a while ago that have been incorporated into apps consuming the `connector-typescript` library via [my fork](https://github.com/jgaehring/connector-typescript/tree/alpha-10) for a while now.

As noted in [`src/org/datafoodconsortium/connector/codegen/typescript/static/CHANGELOG.md`](https://github.com/datafoodconsortium/connector-codegen/blob/d6490a81423f4d0acd71468a4c97d9456decd8d8/src/org/datafoodconsortium/connector/codegen/typescript/static/CHANGELOG.md#100-alpha10---2025-04-28):

> ### Changed
> - Ensure the entry point, `src/index.ts`, is always regenerated on fresh builds.
> - Generated from updated [UML Model](https://github.com/datafoodconsortium/data-model-uml/):
>   - Release: [3.0.0](https://github.com/datafoodconsortium/data-model-uml/releases/tag/v3.0.0)
>   - Commit: [@732bc8e](https://github.com/datafoodconsortium/data-model-uml/commit/732bc8e5cbbf55818ce36330a6c58031d740fefa)
> 
> ### Added
> - `DefinedProduct`:
>   - hasVariant
>   - isVariantOf
> 
> ### Fixed
> - Fix setters for array properties so that all items are replaced.

I'm not sure if the `v1.2.0` branch is the best to merge this into just now. I assume not `main`, but the `dev` branch is currently 64 commits behind too.
